### PR TITLE
AAVE Integration

### DIFF
--- a/config/lighter-config.ts
+++ b/config/lighter-config.ts
@@ -16,6 +16,7 @@ const lighterConfigs: {
       [Token.USDC]: '0xcc4a8fa63ce5c6a7f4a7a3d2ebcb738ddcd31209',
     },
     Vault: {},
+    AAVEPool: '',
   },
   [ChainId.ARBITRUM]: {
     Router: '',
@@ -43,6 +44,7 @@ const lighterConfigs: {
       [Token.aArbWBTC]: '0x91746d6f9df58b9807a5bb0e54e4ea86600c2dba',
       [Token.aArbUSDC]: '0x3155c5a49aa31ee99ea7fbcb1258192652a8001c',
     },
+    AAVEPool: '0x794a61358D6845594F94dc1DB02A252b5b4814aD',
   },
 }
 

--- a/config/types.ts
+++ b/config/types.ts
@@ -27,4 +27,5 @@ export interface LighterConfig {
   OrderBooks: Record<OrderBookKey, string>
   Tokens: Partial<Record<Token, string>>
   Vault: Partial<Record<Token, string>>
+  AAVEPool: string
 }

--- a/contracts/MarginWallet.sol
+++ b/contracts/MarginWallet.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.18;
+
+import {IPool} from "@aave/core-v3/contracts/interfaces/IPool.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title MarginWallet
+ * @notice A contract that acts as a smart wallet.
+ * Funds deposited into it will de used as collateral in the AAVE protocol.
+ */
+contract MarginWallet {
+  /// @notice address of the owner of MarginWallet
+  address public immutable owner;
+
+  /// @notice AAVE v3 pool instance
+  IPool public immutable pool;
+
+  /// @dev Modifier that restricts function execution to the contract owner.
+  /// The caller must be the owner of the smart wallet.
+  modifier onlyOwner() {
+    require(msg.sender == owner, "caller must be owner");
+    _;
+  }
+
+  constructor(IPool _pool) {
+    owner = msg.sender;
+    pool = _pool;
+  }
+
+  function deposit(address tokenAddress, uint256 amount) external onlyOwner {
+    IERC20 token = IERC20(tokenAddress);
+    token.transferFrom(msg.sender, address(this), amount);
+    if (token.allowance(address(this), address(pool)) < amount) {
+      token.approve(address(pool), 1 << 255);
+    }
+    pool.deposit(tokenAddress, amount, address(this), 0);
+  }
+
+  function withdraw(address tokenAddress, uint256 amount) external onlyOwner {
+    pool.withdraw(tokenAddress, amount, owner);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "@aave/core-v3": "^1.18.0",
     "@elliottech/lighter-v2-core": "^1.0.1",
     "@openzeppelin/contracts": "^4.7.1"
   },

--- a/test/aave.ts
+++ b/test/aave.ts
@@ -1,0 +1,99 @@
+import {ethers} from 'hardhat'
+import {BigNumber} from 'ethers'
+import {expect} from 'chai'
+import {fundAccount} from './token'
+import {deployTokens, getAAVEPoolAt, getATokenAt, ParseUSDC, ParseWETH, reset} from './shared'
+import {getLighterConfig} from '../config'
+
+export const AAVEStableRate = BigNumber.from(1)
+export const AAVEVariableRate = BigNumber.from(2)
+
+describe('AAVE', async () => {
+  beforeEach(async function () {
+    await reset()
+  })
+
+  it('forks aWETH correctly', async () => {
+    const config = await getLighterConfig()
+    const token = await getATokenAt(config.Tokens['aArbWETH']!)
+    const vault = config.Vault['aArbWETH']!
+    const amount = ParseWETH('200.0')
+
+    // token is configured successfully
+    expect(await token.UNDERLYING_ASSET_ADDRESS()).to.equal(config.Tokens['WETH']!)
+
+    // vault has balance
+    expect(await token.balanceOf(vault)).to.be.greaterThan(amount)
+
+    const [signer] = await ethers.getSigners()
+
+    // user is impersonated successfully and capable to send money
+    await fundAccount(token, signer, amount)
+    expect(await token.balanceOf(signer.address)).to.equal(amount)
+  })
+  it('forks aUSDC.e correctly', async () => {
+    const config = await getLighterConfig()
+    const token = await getATokenAt(config.Tokens['aArbUSDC']!)
+    const vault = config.Vault['aArbUSDC']!
+    const amount = ParseUSDC('200000.0')
+
+    // token is configured successfully
+    expect(await token.UNDERLYING_ASSET_ADDRESS()).to.equal(config.Tokens['USDC'])
+
+    // vault has balance
+    expect(await token.balanceOf(vault)).to.be.greaterThan(amount)
+
+    const [signer] = await ethers.getSigners()
+
+    // user is impersonated successfully and capable to send money
+    await fundAccount(token, signer, amount)
+    expect(await token.balanceOf(signer.address)).to.equal(amount)
+  })
+
+  it('it can deposit USDC.e', async () => {
+    const config = await getLighterConfig()
+    const pool = await getAAVEPoolAt(config.AAVEPool)
+    const [signer] = await ethers.getSigners()
+
+    const {ausdc, usdc} = await deployTokens()
+    const amount = ParseUSDC(100)
+    await fundAccount(usdc, signer, amount)
+
+    await usdc.approve(pool.address, amount)
+
+    await pool.deposit(usdc.address, amount, signer.address, 0)
+    expect(await ausdc.balanceOf(signer.address)).to.equal(amount)
+  })
+  it('it can deposit WETH', async () => {
+    const config = await getLighterConfig()
+    const pool = await getAAVEPoolAt(config.AAVEPool)
+    const [signer] = await ethers.getSigners()
+
+    const {aweth, weth} = await deployTokens()
+    const amount = ParseWETH(1)
+    await fundAccount(weth, signer, amount)
+
+    await weth.approve(pool.address, amount)
+
+    await pool.deposit(weth.address, amount, signer.address, 0)
+    expect(await aweth.balanceOf(signer.address)).to.equal(amount)
+  })
+  it('it can borrow USDC.e', async () => {
+    const config = await getLighterConfig()
+    const pool = await getAAVEPoolAt(config.AAVEPool)
+    const [signer] = await ethers.getSigners()
+    const {vusdc, usdc, weth} = await deployTokens()
+
+    // deposit 1 ETH
+    const ethAmount = ParseWETH(1)
+    await fundAccount(weth, signer, ethAmount)
+    await weth.approve(pool.address, ethAmount)
+    await pool.deposit(weth.address, ethAmount, signer.address, 0)
+
+    // borrow 1K USD
+    const usdcAmount = ParseUSDC(1000)
+    await pool.borrow(usdc.address, usdcAmount, AAVEVariableRate, 0, signer.address)
+    expect(await usdc.balanceOf(signer.address)).to.equal(usdcAmount)
+    expect(await vusdc.balanceOf(signer.address)).to.equal(usdcAmount)
+  })
+})

--- a/test/margin_wallet.ts
+++ b/test/margin_wallet.ts
@@ -1,0 +1,43 @@
+import {ethers} from 'hardhat'
+import {IPool} from '@aave/core-v3/dist/types/types'
+import {MarginWallet} from '../typechain-types'
+import {expect} from 'chai'
+import {deployTokens, ParseUSDC, getAAVEPoolAt, reset} from './shared'
+import {fundAccount} from './token'
+import {getLighterConfig} from '../config'
+
+async function deployMarginWallet(pool: IPool) {
+  const factory = await ethers.getContractFactory('MarginWallet')
+  return (await factory.deploy(pool.address)) as MarginWallet
+}
+
+describe('Margin wallet', async () => {
+  beforeEach(async function () {
+    await reset()
+  })
+
+  it('it deposits and withdraws', async () => {
+    const [signer] = await ethers.getSigners()
+    const config = await getLighterConfig()
+    const pool = await getAAVEPoolAt(config.AAVEPool)
+    const wallet = await deployMarginWallet(pool)
+
+    const {ausdc, usdc} = await deployTokens()
+    const amount = ParseUSDC(100)
+    await fundAccount(usdc, signer, amount)
+
+    await usdc.approve(wallet.address, amount)
+
+    // deposit into wallet
+    await wallet.deposit(usdc.address, amount)
+    expect(await ausdc.balanceOf(wallet.address)).to.equal(amount)
+    expect(await usdc.balanceOf(signer.address)).to.equal(0)
+    expect(await usdc.balanceOf(wallet.address)).to.equal(0)
+
+    // withdraw from wallet
+    await wallet.withdraw(usdc.address, amount)
+    expect(await ausdc.balanceOf(wallet.address)).to.lt(10) // use < 10 since there might be some interest accrued
+    expect(await usdc.balanceOf(signer.address)).to.equal(amount)
+    expect(await usdc.balanceOf(wallet.address)).to.equal(0)
+  })
+})

--- a/test/shared/amount.ts
+++ b/test/shared/amount.ts
@@ -1,0 +1,21 @@
+import {BigNumber, BigNumberish, utils} from 'ethers'
+
+export function ParseWETH(value: BigNumberish): BigNumber {
+  if (typeof value == 'string') {
+    return utils.parseUnits(value, 18)
+  }
+  if (typeof value == 'number') {
+    return BigNumber.from(value * 100000000).mul(BigNumber.from(10).pow(10))
+  }
+  return BigNumber.from(value).mul(BigNumber.from(10).pow(18))
+}
+
+export function ParseUSDC(value: BigNumberish): BigNumber {
+  if (typeof value == 'string') {
+    return utils.parseUnits(value, 6)
+  }
+  if (typeof value == 'number') {
+    return BigNumber.from(value * 1000000)
+  }
+  return BigNumber.from(value).mul(BigNumber.from(10).pow(6))
+}

--- a/test/shared/deploy.ts
+++ b/test/shared/deploy.ts
@@ -1,0 +1,35 @@
+import * as IAToken from '@aave/core-v3/artifacts/contracts/interfaces/IAToken.sol/IAToken.json'
+import * as AAVEPoolV3 from '@aave/core-v3/artifacts/contracts/protocol/pool/Pool.sol/Pool.json'
+import {AToken, Pool} from '@aave/core-v3/dist/types/types'
+import {ethers} from 'hardhat'
+import {Contract} from 'ethers'
+import {getLighterConfig} from '../../config'
+import {IERC20Metadata} from '../../typechain-types'
+
+export async function getAAVEPoolAt(address: string): Promise<Pool> {
+  const [signer] = await ethers.getSigners()
+  return new Contract(address, AAVEPoolV3.abi, signer) as Pool
+}
+
+export async function getTokenAt(address: string): Promise<IERC20Metadata> {
+  const [signer] = await ethers.getSigners()
+  return (await ethers.getContractAt('IERC20Metadata', address, signer)) as IERC20Metadata
+}
+
+export async function getATokenAt(address: string) {
+  const [signer] = await ethers.getSigners()
+  return new Contract(address, IAToken.abi, signer) as AToken
+}
+
+export async function deployTokens() {
+  const config = await getLighterConfig()
+  return {
+    weth: await getTokenAt(config.Tokens['WETH']!),
+    aweth: await getATokenAt(config.Tokens['aArbWETH']!),
+    vweth: await getTokenAt(config.Tokens['vArbWETH']!),
+
+    usdc: await getTokenAt(config.Tokens['USDC']!),
+    ausdc: await getATokenAt(config.Tokens['aArbUSDC']!),
+    vusdc: await getTokenAt(config.Tokens['vArbUSDC']!),
+  }
+}

--- a/test/shared/hardhat.ts
+++ b/test/shared/hardhat.ts
@@ -1,0 +1,16 @@
+import {network} from 'hardhat'
+import {HardhatNetworkConfig} from 'hardhat/types'
+
+export async function reset() {
+  await network.provider.request({
+    method: 'hardhat_reset',
+    params: [
+      {
+        forking: {
+          jsonRpcUrl: (network.config as HardhatNetworkConfig).forking!.url,
+          blockNumber: (network.config as HardhatNetworkConfig).forking!.blockNumber,
+        },
+      },
+    ],
+  })
+}

--- a/test/shared/index.ts
+++ b/test/shared/index.ts
@@ -1,0 +1,3 @@
+export * from './amount'
+export * from './deploy'
+export * from './hardhat'

--- a/test/token.ts
+++ b/test/token.ts
@@ -1,15 +1,11 @@
-import {IERC20, IERC20Metadata} from '../typechain-types'
+import {IERC20} from '../typechain-types'
 import {ethers} from 'hardhat'
 import {expect} from 'chai'
 import {parseEther, parseUnits} from 'ethers/lib/utils'
-import {Token, getLighterConfig} from 'config'
+import {Token, getLighterConfig} from '../config'
 import {BigNumber} from 'ethers'
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers'
-
-export async function getTokenAt(address: string): Promise<IERC20Metadata> {
-  const [signer] = await ethers.getSigners()
-  return (await ethers.getContractAt('IERC20Metadata', address, signer)) as IERC20Metadata
-}
+import {getTokenAt, reset} from './shared'
 
 // send specified amount to recipient
 // the funds are being send from the configured Vault address for that token, since tokens are not mintable
@@ -33,6 +29,10 @@ export async function fundAccount(token: IERC20, recipient: string | SignerWithA
 }
 
 describe('token', async () => {
+  beforeEach(async function () {
+    await reset()
+  })
+
   it('forks WETH correctly', async () => {
     const config = await getLighterConfig()
     const token = await getTokenAt(config.Tokens['WETH']!)


### PR DESCRIPTION
- add AAVE pool address in config
- add tests for AAVE tokens, checking that vaults & tokens are set up correctly
- add tests which deposits & borrows using AAVE protocol
- add `MarginWallet` contract to serve as a starting point for margin trading, which only deposits in AAVE at the moment