### PR TITLE
Add swap wallet

### DIFF
--- a/config/lighter-config.ts
+++ b/config/lighter-config.ts
@@ -14,6 +14,15 @@ const lighterConfigs: {
       [Token.WETH]: '0x4d541f0b8039643783492f9865c7f7de4f54eb5f',
       [Token.WBTC]: '0xf133eb356537f0b3b4fdfb98233b45ef8138aa56',
       [Token.USDC]: '0xcc4a8fa63ce5c6a7f4a7a3d2ebcb738ddcd31209',
+
+      // this are not real AAVE tokens, but they are here so the tests are passing
+      // when deploying tokens using testnet forking
+      [Token.aArbWETH]: '0x4d541f0b8039643783492f9865c7f7de4f54eb5f',
+      [Token.aArbWBTC]: '0xf133eb356537f0b3b4fdfb98233b45ef8138aa56',
+      [Token.aArbUSDC]: '0xcc4a8fa63ce5c6a7f4a7a3d2ebcb738ddcd31209',
+      [Token.vArbWETH]: '0x4d541f0b8039643783492f9865c7f7de4f54eb5f',
+      [Token.vArbWBTC]: '0xf133eb356537f0b3b4fdfb98233b45ef8138aa56',
+      [Token.vArbUSDC]: '0xcc4a8fa63ce5c6a7f4a7a3d2ebcb738ddcd31209',
     },
     Vault: {
       [Token.WETH]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
@@ -58,7 +67,11 @@ async function getChainId(): Promise<ChainId> {
   return parseInt(chainId as string)
 }
 
-export async function getLighterConfig() {
+export async function getLighterConfig(forceTestnet?: boolean) {
+  if (forceTestnet) {
+    return lighterConfigs[ChainId.ARBITRUM_GOERLI]
+  }
+
   const chainId = await getChainId()
   if (!chainId) {
     throw new Error(`ChainId ${chainId} is not supported`)

--- a/config/lighter-config.ts
+++ b/config/lighter-config.ts
@@ -15,7 +15,11 @@ const lighterConfigs: {
       [Token.WBTC]: '0xf133eb356537f0b3b4fdfb98233b45ef8138aa56',
       [Token.USDC]: '0xcc4a8fa63ce5c6a7f4a7a3d2ebcb738ddcd31209',
     },
-    Vault: {},
+    Vault: {
+      [Token.WETH]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
+      [Token.WBTC]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
+      [Token.USDC]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
+    },
     AAVEPool: '',
   },
   [ChainId.ARBITRUM]: {

--- a/contracts/MarginWallet.sol
+++ b/contracts/MarginWallet.sol
@@ -10,34 +10,34 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  * Funds deposited into it will de used as collateral in the AAVE protocol.
  */
 contract MarginWallet {
-  /// @notice address of the owner of MarginWallet
-  address public immutable owner;
+    /// @notice address of the owner of MarginWallet
+    address public immutable owner;
 
-  /// @notice AAVE v3 pool instance
-  IPool public immutable pool;
+    /// @notice AAVE v3 pool instance
+    IPool public immutable pool;
 
-  /// @dev Modifier that restricts function execution to the contract owner.
-  /// The caller must be the owner of the smart wallet.
-  modifier onlyOwner() {
-    require(msg.sender == owner, "caller must be owner");
-    _;
-  }
-
-  constructor(IPool _pool) {
-    owner = msg.sender;
-    pool = _pool;
-  }
-
-  function deposit(address tokenAddress, uint256 amount) external onlyOwner {
-    IERC20 token = IERC20(tokenAddress);
-    token.transferFrom(msg.sender, address(this), amount);
-    if (token.allowance(address(this), address(pool)) < amount) {
-      token.approve(address(pool), 1 << 255);
+    /// @dev Modifier that restricts function execution to the contract owner.
+    /// The caller must be the owner of the smart wallet.
+    modifier onlyOwner() {
+        require(msg.sender == owner, "caller must be owner");
+        _;
     }
-    pool.deposit(tokenAddress, amount, address(this), 0);
-  }
 
-  function withdraw(address tokenAddress, uint256 amount) external onlyOwner {
-    pool.withdraw(tokenAddress, amount, owner);
-  }
+    constructor(IPool _pool) {
+        owner = msg.sender;
+        pool = _pool;
+    }
+
+    function deposit(address tokenAddress, uint256 amount) external onlyOwner {
+        IERC20 token = IERC20(tokenAddress);
+        token.transferFrom(msg.sender, address(this), amount);
+        if (token.allowance(address(this), address(pool)) < amount) {
+            token.approve(address(pool), 1 << 255);
+        }
+        pool.deposit(tokenAddress, amount, address(this), 0);
+    }
+
+    function withdraw(address tokenAddress, uint256 amount) external onlyOwner {
+        pool.withdraw(tokenAddress, amount, owner);
+    }
 }

--- a/contracts/SwapWallet.sol
+++ b/contracts/SwapWallet.sol
@@ -99,4 +99,9 @@ contract SwapWallet is ILighterV2TransferCallback {
 
         return orderBook.swapExactSingle(isAsk, false, exactOutput, maxInput, recipient, callbackData);
     }
+
+    function withdraw(address tokenAddress, uint256 amount) external onlyOwner {
+        IERC20 token = IERC20(tokenAddress);
+        require(token.transfer(owner, amount), "Token transfer failed");
+    }
 }

--- a/contracts/SwapWallet.sol
+++ b/contracts/SwapWallet.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IOrderBook} from "@elliottech/lighter-v2-core/contracts/interfaces/IOrderBook.sol";
+import {IFactory} from "@elliottech/lighter-v2-core/contracts/interfaces/IFactory.sol";
+import {ILighterV2TransferCallback, IERC20Minimal} from "@elliottech/lighter-v2-core/contracts/interfaces/ILighterV2TransferCallback.sol";
+
+/**
+ * @title SwapWallet
+ * @notice A wallet which interacts with the Lighter protocol in order to swap tokens.
+ */
+contract SwapWallet is ILighterV2TransferCallback {
+    /// @notice address of the owner of wallet
+    address public immutable owner;
+
+    /// @notice factory instance used to query orderBooks by ID
+    IFactory public immutable factory;
+
+    /// @dev Modifier that restricts function execution to the contract owner.
+    /// The caller must be the owner of the wallet.
+    modifier onlyOwner() {
+        require(msg.sender == owner, "caller must be owner");
+        _;
+    }
+
+    /// @dev Constructor initializes the wallet with a factory contract.
+    /// The owner of the wallet is set to the sender of the deployment transaction.
+    /// @param _factory The address of the factory contract.
+    constructor(IFactory _factory) {
+        owner = msg.sender;
+        factory = _factory;
+    }
+
+    ///  @dev Callback function called by the `orderBook` contract after a successful transfer.
+    ///  This function is used to handle the transfer of `debitTokenAmount` of the `debitToken`.
+    ///  It ensures that only the `orderBook` contract can call this function.
+    /// The transferred tokens are then sent back to the sender.
+    /// @param debitTokenAmount The amount of debit tokens to be transferred.
+    /// @param debitToken The ERC20 token used for the transfer.
+    /// @param data Additional data that can be provided to the function.
+    function lighterV2TransferCallback(
+        uint256 debitTokenAmount,
+        IERC20Minimal debitToken,
+        bytes memory data
+    ) external override {
+        uint8 orderBookId;
+        // unpack data
+        assembly {
+            orderBookId := mload(add(data, 1))
+        }
+
+        address orderBookAddress = factory.getOrderBookFromId(orderBookId);
+
+        require(msg.sender == address(orderBookAddress));
+
+        if (!debitToken.transfer(msg.sender, debitTokenAmount)) {
+            revert();
+        }
+    }
+
+    /// @notice Performs swap in the given order book
+    /// @param orderBookId The unique identifier of the order book
+    /// @param isAsk Whether the order is an ask order
+    /// @param exactInput exactInput to pay for the swap (can be token0 or token1 based on isAsk)
+    /// @param minOutput Minimum output amount expected to recieve from swap (can be token0 or token1 based on isAsk)
+    /// @param recipient The address of the recipient of the output
+    /// @return swappedInput The amount of input taker paid for the swap
+    /// @return swappedOutput The amount of output taker received from the swap
+    function swapExactInput(
+        uint8 orderBookId,
+        bool isAsk,
+        uint256 exactInput,
+        uint256 minOutput,
+        address recipient
+    ) external payable returns (uint256, uint256) {
+        IOrderBook orderBook = IOrderBook(factory.getOrderBookFromId(orderBookId));
+        bytes memory callbackData = abi.encodePacked(orderBookId);
+
+        return orderBook.swapExactSingle(isAsk, true, exactInput, minOutput, recipient, callbackData);
+    }
+
+    /// @notice Performs swap in the given order book
+    /// @param isAsk Whether the order is an ask order
+    /// @param exactOutput exactOutput to receive from the swap (can be token0 or token1 based on isAsk)
+    /// @param maxInput Maximum input that the taker is willing to pay for the swap (can be token0 or token1 based on isAsk)
+    /// @param recipient The address of the recipient of the output
+    /// @return swappedInput The amount of input taker paid for the swap
+    /// @return swappedOutput The amount of output taker received from the swap
+    function swapExactOutput(
+        uint8 orderBookId,
+        bool isAsk,
+        uint256 exactOutput,
+        uint256 maxInput,
+        address recipient
+    ) external payable returns (uint256, uint256) {
+        IOrderBook orderBook = IOrderBook(factory.getOrderBookFromId(orderBookId));
+        bytes memory callbackData = abi.encodePacked(orderBookId);
+
+        return orderBook.swapExactSingle(isAsk, false, exactOutput, maxInput, recipient, callbackData);
+    }
+}

--- a/test/shared/deploy.ts
+++ b/test/shared/deploy.ts
@@ -1,14 +1,20 @@
 import * as IAToken from '@aave/core-v3/artifacts/contracts/interfaces/IAToken.sol/IAToken.json'
 import * as AAVEPoolV3 from '@aave/core-v3/artifacts/contracts/protocol/pool/Pool.sol/Pool.json'
-import {AToken, Pool} from '@aave/core-v3/dist/types/types'
+import {AToken, IPool} from '@aave/core-v3/dist/types/types'
 import {ethers} from 'hardhat'
 import {Contract} from 'ethers'
 import {getLighterConfig} from '../../config'
-import {IERC20Metadata} from '../../typechain-types'
+import {IERC20Metadata, IFactory} from '../../typechain-types'
+import * as Factory from '@elliottech/lighter-v2-core/artifacts/contracts/Factory.sol/Factory.json'
 
-export async function getAAVEPoolAt(address: string): Promise<Pool> {
+export async function getAAVEPoolAt(address: string): Promise<IPool> {
   const [signer] = await ethers.getSigners()
-  return new Contract(address, AAVEPoolV3.abi, signer) as Pool
+  return new Contract(address, AAVEPoolV3.abi, signer) as IPool
+}
+
+export async function getFactoryAt(address: string): Promise<IFactory> {
+  const [signer] = await ethers.getSigners()
+  return new Contract(address, Factory.abi, signer) as IFactory
 }
 
 export async function getTokenAt(address: string): Promise<IERC20Metadata> {
@@ -25,11 +31,11 @@ export async function deployTokens() {
   const config = await getLighterConfig()
   return {
     weth: await getTokenAt(config.Tokens['WETH']!),
-    aweth: await getATokenAt(config.Tokens['aArbWETH']!),
-    vweth: await getTokenAt(config.Tokens['vArbWETH']!),
+    // aweth: await getATokenAt(config.Tokens['aArbWETH']!),
+    // vweth: await getTokenAt(config.Tokens['vArbWETH']!),
 
     usdc: await getTokenAt(config.Tokens['USDC']!),
-    ausdc: await getATokenAt(config.Tokens['aArbUSDC']!),
-    vusdc: await getTokenAt(config.Tokens['vArbUSDC']!),
+    // ausdc: await getATokenAt(config.Tokens['aArbUSDC']!),
+    // vusdc: await getTokenAt(config.Tokens['vArbUSDC']!),
   }
 }

--- a/test/shared/deploy.ts
+++ b/test/shared/deploy.ts
@@ -1,6 +1,6 @@
-import * as IAToken from '@aave/core-v3/artifacts/contracts/interfaces/IAToken.sol/IAToken.json'
+import * as IATokenABI from '@aave/core-v3/artifacts/contracts/interfaces/IAToken.sol/IAToken.json'
 import * as AAVEPoolV3 from '@aave/core-v3/artifacts/contracts/protocol/pool/Pool.sol/Pool.json'
-import {AToken, IPool} from '@aave/core-v3/dist/types/types'
+import {IAToken, IPool} from '@aave/core-v3/dist/types/types'
 import {ethers} from 'hardhat'
 import {Contract} from 'ethers'
 import {getLighterConfig} from '../../config'
@@ -24,7 +24,7 @@ export async function getTokenAt(address: string): Promise<IERC20Metadata> {
 
 export async function getATokenAt(address: string) {
   const [signer] = await ethers.getSigners()
-  return new Contract(address, IAToken.abi, signer) as AToken
+  return new Contract(address, IATokenABI.abi, signer) as IAToken
 }
 
 export async function deployTokens() {

--- a/test/shared/deploy.ts
+++ b/test/shared/deploy.ts
@@ -31,11 +31,11 @@ export async function deployTokens() {
   const config = await getLighterConfig()
   return {
     weth: await getTokenAt(config.Tokens['WETH']!),
-    // aweth: await getATokenAt(config.Tokens['aArbWETH']!),
-    // vweth: await getTokenAt(config.Tokens['vArbWETH']!),
+    aweth: await getATokenAt(config.Tokens['aArbWETH']!),
+    vweth: await getTokenAt(config.Tokens['vArbWETH']!),
 
     usdc: await getTokenAt(config.Tokens['USDC']!),
-    // ausdc: await getATokenAt(config.Tokens['aArbUSDC']!),
-    // vusdc: await getTokenAt(config.Tokens['vArbUSDC']!),
+    ausdc: await getATokenAt(config.Tokens['aArbUSDC']!),
+    vusdc: await getTokenAt(config.Tokens['vArbUSDC']!),
   }
 }

--- a/test/shared/deploy.ts
+++ b/test/shared/deploy.ts
@@ -3,7 +3,7 @@ import * as AAVEPoolV3 from '@aave/core-v3/artifacts/contracts/protocol/pool/Poo
 import {IAToken, IPool} from '@aave/core-v3/dist/types/types'
 import {ethers} from 'hardhat'
 import {Contract} from 'ethers'
-import {getLighterConfig} from '../../config'
+import {getLighterConfig, LighterConfig} from '../../config'
 import {IERC20Metadata, IFactory} from '../../typechain-types'
 import * as Factory from '@elliottech/lighter-v2-core/artifacts/contracts/Factory.sol/Factory.json'
 
@@ -27,8 +27,11 @@ export async function getATokenAt(address: string) {
   return new Contract(address, IATokenABI.abi, signer) as IAToken
 }
 
-export async function deployTokens() {
-  const config = await getLighterConfig()
+export async function deployTokens(config?: LighterConfig) {
+  if (config == null) {
+    config = await getLighterConfig()
+  }
+
   return {
     weth: await getTokenAt(config.Tokens['WETH']!),
     aweth: await getATokenAt(config.Tokens['aArbWETH']!),

--- a/test/swap_wallet.ts
+++ b/test/swap_wallet.ts
@@ -1,0 +1,61 @@
+import {ethers} from 'hardhat'
+import {IFactory, SwapWallet} from '../typechain-types'
+import {deployTokens, ParseUSDC, reset, getFactoryAt, ParseWETH} from './shared'
+import {fundAccount} from './token'
+import {getLighterConfig} from '../config'
+
+async function deploySwapWallet(factory: IFactory) {
+  const contractFactory = await ethers.getContractFactory('SwapWallet')
+  return (await contractFactory.deploy(factory.address)) as SwapWallet
+}
+
+describe('Swap wallet', async () => {
+  beforeEach(async function () {
+    await reset()
+  })
+
+  it('it swaps exact input USDC for WETH', async () => {
+    const config = await getLighterConfig()
+    const factory = await getFactoryAt(config.Factory)
+    const wallet = await deploySwapWallet(factory)
+
+    const {usdc} = await deployTokens()
+    const amount = ParseUSDC(1000)
+    await fundAccount(usdc, wallet.address, amount)
+
+    await wallet.swapExactInput(0, false, amount, ParseWETH(0.25), wallet.address)
+  })
+  it('it swaps exact input WETH for USDC', async () => {
+    const config = await getLighterConfig()
+    const factory = await getFactoryAt(config.Factory)
+    const wallet = await deploySwapWallet(factory)
+
+    const {weth} = await deployTokens()
+    const amount = ParseWETH(1)
+    await fundAccount(weth, wallet.address, amount)
+
+    await wallet.swapExactInput(0, true, amount, ParseUSDC(1000), wallet.address)
+  })
+  it('it swaps exact output USDC for WETH', async () => {
+    const config = await getLighterConfig()
+    const factory = await getFactoryAt(config.Factory)
+    const wallet = await deploySwapWallet(factory)
+
+    const {usdc} = await deployTokens()
+    const amount = ParseUSDC(1000)
+    await fundAccount(usdc, wallet.address, amount)
+
+    await wallet.swapExactOutput(0, false, ParseWETH(0.25), amount, wallet.address)
+  })
+  it('it swaps exact output WETH for USDC', async () => {
+    const config = await getLighterConfig()
+    const factory = await getFactoryAt(config.Factory)
+    const wallet = await deploySwapWallet(factory)
+
+    const {weth} = await deployTokens()
+    const amount = ParseWETH(1)
+    await fundAccount(weth, wallet.address, amount)
+
+    await wallet.swapExactOutput(0, true, ParseUSDC(1000), amount, wallet.address)
+  })
+})

--- a/test/swap_wallet.ts
+++ b/test/swap_wallet.ts
@@ -1,6 +1,6 @@
-import {ethers} from 'hardhat'
+import {ethers, network} from 'hardhat'
 import {IFactory, SwapWallet} from '../typechain-types'
-import {deployTokens, ParseUSDC, reset, getFactoryAt, ParseWETH} from './shared'
+import {deployTokens, ParseUSDC, getFactoryAt, ParseWETH} from './shared'
 import {fundAccount} from './token'
 import {getLighterConfig} from '../config'
 import {expect} from 'chai'
@@ -12,62 +12,72 @@ async function deploySwapWallet(factory: IFactory) {
 
 describe('Swap wallet', async () => {
   beforeEach(async function () {
-    await reset()
+    // TODO: Use mainnet fork when contracts are deployed
+    await network.provider.request({
+      method: 'hardhat_reset',
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: `https://rpc.goerli.arbitrum.gateway.fm/`,
+            blockNumber: 42443400,
+          },
+        },
+      ],
+    })
   })
 
   it('it swaps exact input USDC for WETH', async () => {
-    const config = await getLighterConfig()
+    const config = await getLighterConfig(true)
     const factory = await getFactoryAt(config.Factory)
     const wallet = await deploySwapWallet(factory)
-
-    const {usdc} = await deployTokens()
+    const {usdc} = await deployTokens(config)
     const amount = ParseUSDC(1000)
-    await fundAccount(usdc, wallet.address, amount)
+    await fundAccount(usdc, wallet.address, amount, config)
 
     await wallet.swapExactInput(0, false, amount, ParseWETH(0.25), wallet.address)
   })
   it('it swaps exact input WETH for USDC', async () => {
-    const config = await getLighterConfig()
+    const config = await getLighterConfig(true)
     const factory = await getFactoryAt(config.Factory)
     const wallet = await deploySwapWallet(factory)
 
-    const {weth} = await deployTokens()
+    const {weth} = await deployTokens(config)
     const amount = ParseWETH(1)
-    await fundAccount(weth, wallet.address, amount)
+    await fundAccount(weth, wallet.address, amount, config)
 
     await wallet.swapExactInput(0, true, amount, ParseUSDC(1000), wallet.address)
   })
   it('it swaps exact output USDC for WETH', async () => {
-    const config = await getLighterConfig()
+    const config = await getLighterConfig(true)
     const factory = await getFactoryAt(config.Factory)
     const wallet = await deploySwapWallet(factory)
 
-    const {usdc} = await deployTokens()
+    const {usdc} = await deployTokens(config)
     const amount = ParseUSDC(1000)
-    await fundAccount(usdc, wallet.address, amount)
+    await fundAccount(usdc, wallet.address, amount, config)
 
     await wallet.swapExactOutput(0, false, ParseWETH(0.25), amount, wallet.address)
   })
   it('it swaps exact output WETH for USDC', async () => {
-    const config = await getLighterConfig()
+    const config = await getLighterConfig(true)
     const factory = await getFactoryAt(config.Factory)
     const wallet = await deploySwapWallet(factory)
 
-    const {weth} = await deployTokens()
+    const {weth} = await deployTokens(config)
     const amount = ParseWETH(1)
-    await fundAccount(weth, wallet.address, amount)
+    await fundAccount(weth, wallet.address, amount, config)
 
     await wallet.swapExactOutput(0, true, ParseUSDC(1000), amount, wallet.address)
   })
 
   it('can withdraw tokens', async () => {
-    const config = await getLighterConfig()
+    const config = await getLighterConfig(true)
     const factory = await getFactoryAt(config.Factory)
     const wallet = await deploySwapWallet(factory)
 
-    const {weth} = await deployTokens()
+    const {weth} = await deployTokens(config)
     const amount = ParseWETH(1)
-    await fundAccount(weth, wallet.address, amount)
+    await fundAccount(weth, wallet.address, amount, config)
 
     await wallet.withdraw(weth.address, amount)
 

--- a/test/token.ts
+++ b/test/token.ts
@@ -2,21 +2,29 @@ import {IERC20} from '../typechain-types'
 import {ethers} from 'hardhat'
 import {expect} from 'chai'
 import {parseEther, parseUnits} from 'ethers/lib/utils'
-import {Token, getLighterConfig} from '../config'
+import {Token, getLighterConfig, LighterConfig} from '../config'
 import {BigNumber} from 'ethers'
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers'
 import {getTokenAt, reset} from './shared'
 
 // send specified amount to recipient
 // the funds are being send from the configured Vault address for that token, since tokens are not mintable
-export async function fundAccount(token: IERC20, recipient: string | SignerWithAddress, amount: BigNumber) {
-  const config = await getLighterConfig()
+export async function fundAccount(
+  token: IERC20,
+  recipient: string | SignerWithAddress,
+  amount: BigNumber,
+  config?: LighterConfig
+) {
+  if (config == null) {
+    config = await getLighterConfig()
+  }
 
   // get vault from token address
   let vaultAddress = null
   for (const s in config.Tokens) {
     if (config.Tokens[s as Token]! == token.address) {
       vaultAddress = config.Vault[s as Token]!
+      break
     }
   }
   if (vaultAddress == null) {


### PR DESCRIPTION
- create sample Wallet which interacts with the Lighter protocol via Swaps
- the wallet does not provide any market making functionality, because it does not create any resting orders
- intended to be be used by aggregators or in general people who want to take advantage of the prices on Lighter
- tests are passing but they use testnet forking, due to the fact that contracts are not deployed on mainnet yet