### PR TITLE
Use mainnet forking

### DIFF
--- a/config/lighter-config.ts
+++ b/config/lighter-config.ts
@@ -30,34 +30,24 @@ export const lighterConfigs: {
   [ChainId: string]: LighterConfig
 } = {
   [ChainId.ARBITRUM_GOERLI]: {
-    Router: '0x69533aA255E728995044baD3F713EA0F3E786c98',
-    Factory: '0xF38d66921bD3d26A92886dbB1ee49bE669E3FCfE',
+    Router: '0xc86E2d10e6C4F2b300c40C7d52f23F7625eCf436',
+    Factory: '0x2290519aAaae9D9F6571691232cb8a1e8f001c53',
     OrderBooks: {
-      [OrderBookKey.WETH_USDC]: '0xc5aac3b83228a5c69efb4c60c00a45b576230a50',
-      [OrderBookKey.WBTC_USDC]: '0xca31078c52f770ba2ea95bfbe327a25cfc793230',
-      [OrderBookKey.USDT_USDC]: '0x697a5879bad95037929951bc719b3cb8f15bc867',
+      [OrderBookKey.WETH_USDC]: '0xc3481aD2d1113EfabAB0d7c4991AE137C966e90f',
+      [OrderBookKey.WBTC_USDC]: '0x74Ca7998c6aABA413E9aeCD944770B7AA6B5B59E',
+      [OrderBookKey.USDT_USDC]: '0xCE1BBE1868CE5912b6fD6d5fA5754C41B11e8f7a',
     },
     Tokens: {
       [Token.WETH]: '0x4d541f0b8039643783492f9865c7f7de4f54eb5f',
       [Token.WBTC]: '0xf133eb356537f0b3b4fdfb98233b45ef8138aa56',
       [Token.USDC]: '0xcc4a8fa63ce5c6a7f4a7a3d2ebcb738ddcd31209',
       [Token.USDT]: '0x03fc54FD8572B76b6F4f5177A016Bac11688Fc5F',
-
-      // this are not real AAVE tokens, but they are here so the tests are passing
-      // when deploying tokens using testnet forking
-      [Token.aArbWETH]: '0x4d541f0b8039643783492f9865c7f7de4f54eb5f',
-      [Token.aArbWBTC]: '0xf133eb356537f0b3b4fdfb98233b45ef8138aa56',
-      [Token.aArbUSDC]: '0xcc4a8fa63ce5c6a7f4a7a3d2ebcb738ddcd31209',
-      [Token.vArbWETH]: '0x4d541f0b8039643783492f9865c7f7de4f54eb5f',
-      [Token.vArbWBTC]: '0xf133eb356537f0b3b4fdfb98233b45ef8138aa56',
-      [Token.vArbUSDC]: '0xcc4a8fa63ce5c6a7f4a7a3d2ebcb738ddcd31209',
     },
     Vault: {
       [Token.WETH]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
       [Token.WBTC]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
       [Token.USDC]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
     },
-    AAVEPool: '',
   },
   [ChainId.ARBITRUM]: {
     Router: '0x86D4Ef07492605D30124E25B1E08E3C489D39807',
@@ -100,22 +90,12 @@ export const lighterConfigs: {
       [Token.WETH]: '0x813A9650cda5512a4c6791bb98a30716C5F9FB84',
       [Token.WMATIC]: '0x5d9D20BC86bEEC389B79b247096116deE1B439eC',
       [Token.USDC]: '0x814d30D1bEF64BDca1Ca5CD7631D26C0E057A79b',
-
-      // this are not real AAVE tokens, but they are here so the tests are passing
-      // when deploying tokens using testnet forking
-      [Token.aArbWETH]: '',
-      [Token.aArbWBTC]: '',
-      [Token.aArbUSDC]: '',
-      [Token.vArbWETH]: '',
-      [Token.vArbWBTC]: '',
-      [Token.vArbUSDC]: '',
     },
     Vault: {
       [Token.WETH]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
       [Token.WBTC]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
       [Token.USDC]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
     },
-    AAVEPool: '',
   },
   [ChainId.BSC_TESTNET]: {
     Router: '0xBDeFBfC2134E584EA7d1C8124Ca77157afaae9c6',
@@ -140,7 +120,6 @@ export const lighterConfigs: {
       [Token.BTCB]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
       [Token.USDC]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
     },
-    AAVEPool: '',
   },
   [ChainId.OPT_GOERLI]: {
     Router: '0xD1282905bE4Cbc10F3FA121F0dD515Ea51Be0026',
@@ -159,7 +138,6 @@ export const lighterConfigs: {
       [Token.WBTC]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
       [Token.USDC]: '0x86A9E67c3aE6B87Cc23652B2d72a21CB80dec146',
     },
-    AAVEPool: '',
   },
 }
 

--- a/config/lighter-config.ts
+++ b/config/lighter-config.ts
@@ -84,7 +84,7 @@ export const lighterConfigs: {
       [Token.USDC]: '0x5bdf85216ec1e38d6458c870992a69e38e03f7ef',
       [Token.aArbWETH]: '0x6286b9f080d27f860f6b4bb0226f8ef06cc9f2fc',
       [Token.aArbWBTC]: '0x91746d6f9df58b9807a5bb0e54e4ea86600c2dba',
-      [Token.aArbUSDC]: '0x3155c5a49aa31ee99ea7fbcb1258192652a8001c',
+      [Token.aArbUSDC]: '0x3a5385d8eb0d05b006edff978ba4b95c51f70b5c',
     },
     AAVEPool: '0x794a61358D6845594F94dc1DB02A252b5b4814aD',
   },
@@ -216,11 +216,7 @@ async function getChainId(): Promise<ChainId> {
   return parseInt(chainId as string)
 }
 
-export async function getLighterConfig(forceTestnet?: boolean) {
-  if (forceTestnet) {
-    return lighterConfigs[ChainId.ARBITRUM_GOERLI]
-  }
-
+export async function getLighterConfig() {
   const chainId = await getChainId()
   if (!chainId) {
     throw new Error(`ChainId ${chainId} is not supported`)

--- a/config/types.ts
+++ b/config/types.ts
@@ -54,7 +54,7 @@ export interface LighterConfig {
   OrderBooks: Partial<Record<OrderBookKey, string>>
   Tokens: Partial<Record<Token, string>>
   Vault: Partial<Record<Token, string>>
-  AAVEPool: string
+  AAVEPool?: string
 }
 
 export interface OrderBookConfig {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -12,7 +12,7 @@ const config: HardhatUserConfig = {
     hardhat: {
       forking: {
         url: process.env.ARBITRUM_MAINNET_URL ? process.env.ARBITRUM_MAINNET_URL : `https://arb1.arbitrum.io/rpc`,
-        blockNumber: 132173014,
+        blockNumber: 143468900,
       },
     },
     arbgoerli: {

--- a/shared/order-view.ts
+++ b/shared/order-view.ts
@@ -81,9 +81,8 @@ export const getAllLimitOrdersBySide = async (
   isAsk: boolean,
   limit: number
 ): Promise<Order[]> => {
-  let orderData = {}
   try {
-    orderData = await orderBookContract.getPaginatedOrders(startOrderId, isAsk, limit)
+    const orderData = await orderBookContract.getPaginatedOrders(startOrderId, isAsk, limit)
     return parseOrders(isAsk, orderData)
   } catch (error) {
     return []
@@ -91,16 +90,14 @@ export const getAllLimitOrdersBySide = async (
 }
 
 export const parseOrders = (isAsk: boolean, orderData: IOrderBook.OrderQueryItemStructOutput): Order[] => {
-  const [ids, owners, amount0s, prices] = orderData.slice(1) // Skip the first item in orderData
-
   const orders: Order[] = []
 
   //@ts-ignore
-  for (let i = 0; i < ids.length; i++) {
-    const id = BigNumber.from(ids[i].toString())
-    const owner = owners[i].toString()
-    const amount0 = BigNumber.from(amount0s[i].toString())
-    const price = BigNumber.from(prices[i].toString())
+  for (let i = 1; i < orderData.ids.length; i++) {
+    const id = BigNumber.from(orderData.ids[i].toString())
+    const owner = orderData.owners[i].toString()
+    const amount0 = BigNumber.from(orderData.amount0s[i].toString())
+    const price = BigNumber.from(orderData.prices[i].toString())
 
     if (owner !== '0x0000000000000000000000000000000000000000') {
       orders.push({id, isAsk, owner, amount0, price, orderType: OrderType.LimitOrder})

--- a/tasks/lighter-orders.ts
+++ b/tasks/lighter-orders.ts
@@ -105,7 +105,7 @@ task('createOrder')
     const lighterConfig = await getLighterConfig()
     const orderBookAddress = lighterConfig.OrderBooks[orderbookname as OrderBookKey]
 
-    if(!orderBookAddress) {
+    if (!orderBookAddress) {
       throw new Error(`Invalid OrderbookAddress`)
     }
 
@@ -175,6 +175,9 @@ task('cancelOrder')
   .setAction(async ({orderbookname, id}, hre) => {
     const lighterConfig = await getLighterConfig()
     const orderBookAddress = lighterConfig.OrderBooks[orderbookname as OrderBookKey]
+    if (!orderBookAddress) {
+      throw new Error(`Invalid OrderbookAddress`)
+    }
     const orderBookConfig = await getOrderBookConfigFromAddress(orderBookAddress, hre)
 
     const txData = getCancelLimitOrderFallbackData(orderBookConfig.orderBookId, [id])

--- a/tasks/lighter-swaps.ts
+++ b/tasks/lighter-swaps.ts
@@ -67,6 +67,9 @@ task('swapExactInput')
     const lighterConfig = await getLighterConfig()
     const routerContract = await getRouterAt(lighterConfig.Router, hre)
     const orderBookAddress = lighterConfig.OrderBooks[orderbookname as OrderBookKey]
+    if (!orderBookAddress) {
+      throw new Error(`Invalid OrderbookAddress`)
+    }
     const orderBookConfig = await getOrderBookConfigFromAddress(orderBookAddress, hre)
     const exactInputAmount = parseAmount(
       exactinput,

--- a/test/aave.ts
+++ b/test/aave.ts
@@ -51,7 +51,7 @@ describe('AAVE', async () => {
 
   it('it can deposit USDC.e', async () => {
     const config = await getLighterConfig()
-    const pool = await getAAVEPoolAt(config.AAVEPool)
+    const pool = await getAAVEPoolAt(config.AAVEPool!)
     const [signer] = await ethers.getSigners()
 
     const {ausdc, usdc} = await deployTokens()
@@ -65,7 +65,7 @@ describe('AAVE', async () => {
   })
   it('it can deposit WETH', async () => {
     const config = await getLighterConfig()
-    const pool = await getAAVEPoolAt(config.AAVEPool)
+    const pool = await getAAVEPoolAt(config.AAVEPool!)
     const [signer] = await ethers.getSigners()
 
     const {aweth, weth} = await deployTokens()
@@ -79,7 +79,7 @@ describe('AAVE', async () => {
   })
   it('it can borrow USDC.e', async () => {
     const config = await getLighterConfig()
-    const pool = await getAAVEPoolAt(config.AAVEPool)
+    const pool = await getAAVEPoolAt(config.AAVEPool!)
     const [signer] = await ethers.getSigners()
     const {vusdc, usdc, weth} = await deployTokens()
 

--- a/test/aave.ts
+++ b/test/aave.ts
@@ -1,8 +1,7 @@
 import {ethers} from 'hardhat'
 import {BigNumber} from 'ethers'
 import {expect} from 'chai'
-import {fundAccount} from './token'
-import {deployTokens, getAAVEPoolAt, getATokenAt, ParseUSDC, ParseWETH, reset} from './shared'
+import {deployTokens, fundAccount, getAAVEPoolAt, getATokenAt, ParseUSDC, ParseWETH, reset} from './shared'
 import {getLighterConfig} from '../config'
 
 export const AAVEStableRate = BigNumber.from(1)

--- a/test/margin_wallet.ts
+++ b/test/margin_wallet.ts
@@ -1,7 +1,6 @@
 import {ethers} from 'hardhat'
 import {expect} from 'chai'
-import {deployTokens, ParseUSDC, getAAVEPoolAt, reset, deployMarginWallet} from './shared'
-import {fundAccount} from './token'
+import {deployTokens, ParseUSDC, getAAVEPoolAt, reset, deployMarginWallet, fundAccount} from './shared'
 import {getLighterConfig} from '../config'
 
 describe('Margin wallet', async () => {

--- a/test/margin_wallet.ts
+++ b/test/margin_wallet.ts
@@ -11,7 +11,7 @@ describe('Margin wallet', async () => {
   it('it deposits and withdraws', async () => {
     const [signer] = await ethers.getSigners()
     const config = await getLighterConfig()
-    const pool = await getAAVEPoolAt(config.AAVEPool)
+    const pool = await getAAVEPoolAt(config.AAVEPool!)
     const wallet = await deployMarginWallet(pool)
 
     const {ausdc, usdc} = await deployTokens()

--- a/test/shared/hardhat.ts
+++ b/test/shared/hardhat.ts
@@ -14,19 +14,3 @@ export async function reset() {
     ],
   })
 }
-
-export async function resetTestnet() {
-  await network.provider.request({
-    method: 'hardhat_reset',
-    params: [
-      {
-        forking: {
-          jsonRpcUrl: process.env.ARBITRUM_TESTNET_URL
-            ? process.env.ARBITRUM_TESTNET_URL
-            : `https://rpc.goerli.arbitrum.gateway.fm/`,
-          blockNumber: 42443400,
-        },
-      },
-    ],
-  })
-}

--- a/test/swap_wallet.ts
+++ b/test/swap_wallet.ts
@@ -1,32 +1,31 @@
 import {ethers} from 'hardhat'
-import {ParseUSDC, ParseWETH, resetTestnet, deployContracts} from './shared'
+import {ParseUSDC, ParseWETH, reset, deployContracts} from './shared'
 import {expect} from 'chai'
 
 describe('Swap wallet', async () => {
   beforeEach(async function () {
-    // TODO: Use mainnet fork when contracts are deployed
-    await resetTestnet()
+    await reset()
   })
 
   it('it swaps exact input USDC for WETH', async () => {
     const {swapWallet: wallet, orderBook} = await deployContracts(true)
 
-    await wallet.swapExactInput(orderBook.address, false, ParseUSDC(1000), ParseWETH(0.25), wallet.address)
+    await wallet.swapExactInput(orderBook.address, false, ParseUSDC(1000), ParseWETH('0.45'), wallet.address)
   })
   it('it swaps exact input WETH for USDC', async () => {
     const {swapWallet: wallet, orderBook} = await deployContracts(true)
 
-    await wallet.swapExactInput(orderBook.address, true, ParseWETH(1.0), ParseUSDC(1000), wallet.address)
+    await wallet.swapExactInput(orderBook.address, true, ParseWETH(0.5), ParseUSDC(900), wallet.address)
   })
   it('it swaps exact output USDC for WETH', async () => {
     const {swapWallet: wallet, orderBook} = await deployContracts(true)
 
-    await wallet.swapExactOutput(orderBook.address, false, ParseWETH(0.25), ParseUSDC(1000), wallet.address)
+    await wallet.swapExactOutput(orderBook.address, false, ParseWETH(0.5), ParseUSDC(1100), wallet.address)
   })
   it('it swaps exact output WETH for USDC', async () => {
     const {swapWallet: wallet, orderBook} = await deployContracts(true)
 
-    await wallet.swapExactOutput(orderBook.address, true, ParseUSDC(1000), ParseWETH(1.0), wallet.address)
+    await wallet.swapExactOutput(orderBook.address, true, ParseUSDC(1000), ParseWETH('0.55'), wallet.address)
   })
 
   it('can withdraw tokens', async () => {

--- a/test/token.ts
+++ b/test/token.ts
@@ -1,40 +1,8 @@
-import {IERC20} from '../typechain-types'
 import {ethers} from 'hardhat'
 import {expect} from 'chai'
 import {parseEther, parseUnits} from 'ethers/lib/utils'
-import {Token, getLighterConfig, LighterConfig} from '../config'
-import {BigNumber} from 'ethers'
-import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers'
-import {getTokenAt, reset} from './shared'
-
-// send specified amount to recipient
-// the funds are being send from the configured Vault address for that token, since tokens are not mintable
-export async function fundAccount(
-  token: IERC20,
-  recipient: string | SignerWithAddress,
-  amount: BigNumber,
-  config?: LighterConfig
-) {
-  if (config == null) {
-    config = await getLighterConfig()
-  }
-
-  // get vault from token address
-  let vaultAddress = null
-  for (const s in config.Tokens) {
-    if (config.Tokens[s as Token]! == token.address) {
-      vaultAddress = config.Vault[s as Token]!
-      break
-    }
-  }
-  if (vaultAddress == null) {
-    throw `token ${token.address} is not used`
-  }
-  const vault = await ethers.getImpersonatedSigner(vaultAddress)
-
-  const recipientAddress = typeof recipient == 'string' ? recipient : recipient.address
-  return token.connect(vault).transfer(recipientAddress, amount)
-}
+import {getLighterConfig} from '../config'
+import {fundAccount, getTokenAt, reset} from './shared'
 
 describe('token', async () => {
   beforeEach(async function () {


### PR DESCRIPTION
Now that the Arbitrum contracts are deployed, it's possible to change the unit tests to use forking mode on the Arbitrum network, instead of  Arb Goerli. This involves changing some unit-tests as the order books which are being forked are different.